### PR TITLE
Add GitHub Action workflow for publishing to NPM

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -29,6 +29,6 @@ action "Build library and run tests" {
 action "Publish" {
   uses = "actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680"
   needs = ["Build library and run tests"]
-  args = "pack"
+  args = "publish"
   secrets = ["NPM_AUTH_TOKEN"]
 }


### PR DESCRIPTION
When I create GitHub tag, I want the package to be published to NPM.